### PR TITLE
Fix icon path

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,7 @@
   "description": "Thunderbird plugin to unmangle Outlook Protection Safelinks\n\nBased upon https://github.com/mbattersby/unmangleOutlookSafelinks\nOriginal version by mib@post.com\n\nUsers of Office365 who have Advanced Thread Protection enabled will change\nall URL's in emails to redirect them to an Microsoft filter before opening.\nThis will leak information to Microsoft and makes it impossible to see if\nthe original URL was safe to open.\n\nE.g. a link to\n\thttp://phishingsite.fake.ru/you/are/hacked.php \nwill show as\n\thttps://emea01.safelinks.protection.outlook.com/?url=http%3A%2F%2Fphishingsite.fake.ru%2Fyou%2Fare%2Fhacked.phpdata=02%7C01%7Csender.mail%40domain.tld%7C8177af7905a4406ecae208d5dc1fb7c9%7C87c50b582ef2423da4dbaedde7c84efcfa%7C0%7C0%7C63453351150545403+sdata=Te0O1xGxxxULxdzbxQ%2xxxyql2QjTt4Ken%2F00JB%2BV%2FPUA%3D+reserved=0\n\nand will not be recognized by a user as dangerous.\n\nThis plugin will change the URL back to the original value.\n\nContributors:\nPeter Havekes - peter@havekes.eu\nJan Kiszka - jan.kiszka@web.de\nPetros Koutsolampros",
   "version": "2.01",
   "icons": {
-    "32": "content/icon.png"
+    "32": "chrome/content/icon.png"
   },
   "legacy": {
     "type" : "bootstrap"


### PR DESCRIPTION
On contrast to what the documentation says, referencing "content" from
chrome.manifest does not work.

Signed-off-by: Jan Kiszka <jan.kiszka@web.de>