### PR TITLE
README: Fix addon URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unmangleOutlookSafelinks [Install here](https://addons.thunderbird.net//en-US/thunderbird/addon/unmangle-outlook-safelinks/)
+# unmangleOutlookSafelinks [Install here](https://addons.thunderbird.net/en-US/thunderbird/addon/unmangle-outlook-safelinks/)
 
 Thunderbird plugin to unmangle Outlook Protection Safelinks
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unmangleOutlookSafelinks [Install here](https://addons.mozilla.org/en-US/firefox/addon/unmangle-outlook-safelinks/)
+# unmangleOutlookSafelinks [Install here](https://addons.thunderbird.net//en-US/thunderbird/addon/unmangle-outlook-safelinks/)
 
 Thunderbird plugin to unmangle Outlook Protection Safelinks
 


### PR DESCRIPTION
Thunderbird become indepenent from Mozilla foundation then
addon url changes to thunderbird.net

Signed-off-by: Hiroshi Miura <miurahr@linux.com>