### PR TITLE
Add release by github actions

### DIFF
--- a/.github/workflows/push-releases-xpi.yml
+++ b/.github/workflows/push-releases-xpi.yml
@@ -1,0 +1,34 @@
+name: Publish XPI module to github releases branch
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  makexpi:
+    env:
+      NAME: unmangleOutlookSafelinks
+      OWNER: phavekes
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: fetch all branches
+      run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+    - name: Create xpi and release it
+      run: |
+        export VERSION="${GITHUB_REF##*/}"
+        (cd src && zip -r - .) > /tmp/${NAME}-${VERSION}.xpi
+        git checkout releases
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        mv /tmp/${NAME}-${VERSION}.xpi addon/
+        echo "\n* [v${VERSION}](https://github.com/${OWNER}/unmangleOutlookSafelinks/raw/releases/${NAME}-${VERSION}.xpi)\n" >> README.md
+        git add README.md addon/${NAME}-${VERSION}.xpi
+        git commit -m "Add ${VERSION} artifact by github actions"
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: releases
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-releases-xpi.yml
+++ b/.github/workflows/push-releases-xpi.yml
@@ -24,7 +24,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         mv /tmp/${NAME}-${VERSION}.xpi addon/
-        echo "\n* [v${VERSION}](https://github.com/${OWNER}/unmangleOutlookSafelinks/raw/releases/${NAME}-${VERSION}.xpi)\n" >> README.md
+        echo -ne "\n* [${VERSION}](https://github.com/${OWNER}/unmangleOutlookSafelinks/raw/releases/addon/${NAME}-${VERSION}.xpi)\n" >> README.md
         git add README.md addon/${NAME}-${VERSION}.xpi
         git commit -m "Add ${VERSION} artifact by github actions"
     - name: Push changes


### PR DESCRIPTION
This is a github actions automation to release artifact automatically.
Before merging this PR, you should create releases orphan branch 

```
$ git checkout --orphan releases
$ git reset
$ git add README.md LICENSE
$ mkdir addon
$ mv *.xpi addon/
$ git add addon
$ git commit -asm 'Prepare release orphan branch'
$ git push origin releases
```

This action triggered with tag with v*

It checkout master branch, then retrieve v* tagname and create xpi then push back to github repository's releases branch.

You can see demonstration on https://github.com/miurahr/unmangleOutlookSafelinks/tree/releases



Signed-off-by: Hiroshi Miura <miurahr@linux.com>