### PR TITLE
Add support for demangling proofpoint URL-defense URLs.

### DIFF
--- a/src/chrome/content/unmangle.jsm
+++ b/src/chrome/content/unmangle.jsm
@@ -90,7 +90,6 @@ var unmangleOutlookSafelinks = {
             let v3_token_pattern = new RegExp('\\*(\\*.)?', 'g');
             let length_codes = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
             var url = a.href.match(v3_pattern);
-console.log(url[2].replace(/_/g, '/').replace(/-/g, '+') + '==');
             var encbytes = atob(url[2].replace(/_/g, '/').replace(/-/g, '+'));
             var encbytes_off = 0;
 

--- a/src/chrome/content/unmangle.jsm
+++ b/src/chrome/content/unmangle.jsm
@@ -69,10 +69,10 @@ var unmangleOutlookSafelinks = {
         var v = proofpoint[1];
         var outurl = a;
         if (v == 'v1') {
-            let v1_pattern = new RegExp('https://urldefense(?:\.proofpoint)?\.com/v1/url\\?u=(.*)&k=.*');
+            let v1_pattern = new RegExp('https://urldefense(?:\.proofpoint)?\.com/v1/url\\?u=([^&]*)&k=.*');
             outurl = decodeURIComponent(a.match(v1_pattern)[1]);
         } else if (v == 'v2') {
-            let v2_pattern = new RegExp('https://urldefense(?:\.proofpoint)?\.com/v2/url\\?u=(.*)&[dc]=.*');
+            let v2_pattern = new RegExp('https://urldefense(?:\.proofpoint)?\.com/v2/url\\?u=([^&]*)&[dc]=.*');
             var url = a.match(v2_pattern)[1];
             url = url.replace(/-/g, '%');
             url = url.replace(/_/g, '/');

--- a/src/chrome/content/unmangle.jsm
+++ b/src/chrome/content/unmangle.jsm
@@ -134,6 +134,9 @@ var unmangleOutlookSafelinks = {
         var links = doc.getElementsByTagName("a");
         for (var i=0; i < links.length; i++) {
             unmangleOutlookSafelinks.unmangleLink(links[i]);
+            // Certain deranged e-mail systems use *both*. Undo compounded
+            // mangled links by doing this twice.
+            unmangleOutlookSafelinks.unmangleLink(links[i]);
         }
     },
 


### PR DESCRIPTION
This supports V1-V3 URLs following the documentation at https://help.proofpoint.com/Threat_Insight_Dashboard/Concepts/How_do_I_decode_a_rewritten_URL%3F.

Closes #16 