### PR TITLE
Use URLSearchParams API to extract url from safelink

### DIFF
--- a/src/display.js
+++ b/src/display.js
@@ -13,21 +13,15 @@ function unmangleLink(a) {
     doInner = true;
   }
 
-  var terms = a.search.replace(/^\?/, "").split("&");
-  var i;
-  for (i = 0; i < terms.length; i++) {
-    var s = terms[i].split("=");
-    if (s[0] === "url") {
-      a.href = decodeURIComponent(s[1]);
+  var realURL = (new URLSearchParams(a.search)).get("url")
+  if(realURL){
+      a.href = realURL;
       a.title = "Unmangled Microsoft Safelink";
-
       console.log("Rewrote "+orgUrl+" to "+a.href);
 
       if (doInner) {
         a.textContent = a.href;
       }
-      return;
-    }
   }
 }
 


### PR DESCRIPTION
I replaced the splitting of the url by [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). This simplifies the code a bit.

Thanks for the great work :+1:, this extension is super useful.