### PR TITLE
Fix performance of Sender ID warning blurb removal.

### DIFF
--- a/src/display.js
+++ b/src/display.js
@@ -37,7 +37,8 @@ function decodeURI(match, p1, offset, string) {
 
 
 function unmangleContent(text) {
-  const senderIdRegex = /.*https:\/\/aka\.ms\/LearnAboutSenderIdentification.*(?:\n|<br\s*\/?>)?/gi;
+  // anchored to avoid bad performance
+  const senderIdRegex = /^.*https:\/\/aka\.ms\/LearnAboutSenderIdentification.*(?:\n|<br\s*\/?>)?/gmi;
   text = text.replace(senderIdRegex, "");
   text = text.replace(/https:\/\/[^\.]+\.safelinks\.protection\.outlook\.com\/\?url=([^&]*)&[^>\s]*/g, decodeURI);
   return text;


### PR DESCRIPTION
A global regular expression beginning with “.*” will attempt to match the regular expression at every index of the input. Because “.” matches any character except for newline, this portion of the regular expression will travel the entirety of each line. Combining these provides O(n**2) performance per line of length n which is really noticeable with long lines. To address this, anchor the expression to the beginning of the line so that each line needs to be scanned roughly only once.

This fixes an issue which causes an unresponsive script warning to appear on emails with long lines in the source.

Fixes #25.